### PR TITLE
fix: clean up legacy localStorage key and add cache-busting for static assets

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -101,6 +101,7 @@ async def index(request: Request):
         "index.html",
         {
             "max_chars": 4000,
+            "app_version": app.version,
         },
     )
 

--- a/app/static/js/api-key.js
+++ b/app/static/js/api-key.js
@@ -89,6 +89,9 @@ const ApiKeyUI = {
     async init() {
         this.bindEvents();
 
+        // Clean up legacy localStorage key from pre-session versions
+        localStorage.removeItem('friendly_advice_api_key');
+
         // Check server-side session status (async)
         const hasKey = await ApiKeyManager.checkStatus();
         this.updateSettingsIndicator();

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Friendly Advice Columnist{% endblock %}</title>
-    <link rel="stylesheet" href="/static/css/styles.css">
+    <link rel="stylesheet" href="/static/css/styles.css?v={{ app_version | default('dev') }}">
     <script src="https://unpkg.com/htmx.org@1.9.10"></script>
     {% block head %}{% endblock %}
 </head>
@@ -149,8 +149,8 @@
         </div>
     </div>
 
-    <script src="/static/js/sessions.js"></script>
-    <script src="/static/js/api-key.js"></script>
+    <script src="/static/js/sessions.js?v={{ app_version | default('dev') }}"></script>
+    <script src="/static/js/api-key.js?v={{ app_version | default('dev') }}"></script>
     {% block scripts %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
- Remove old friendly_advice_api_key from localStorage on init so it
  doesn't linger for users upgrading from the pre-session version
- Add ?v=<app_version> query params to CSS/JS includes so browser
  caches are busted on each deploy

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
