### PR TITLE
fix: add cryptography to requirements-web.txt for Docker builds

### DIFF
--- a/requirements-web.txt
+++ b/requirements-web.txt
@@ -7,3 +7,4 @@ python-multipart>=0.0.6
 tomli>=2.0.0;python_version<"3.11"
 boto3>=1.34.0
 slowapi>=0.1.9
+cryptography>=42.0.0


### PR DESCRIPTION
The Dockerfile uses requirements-web.txt, not requirements.txt.
Missing cryptography package caused the container to crash on startup,
triggering an App Runner rollback.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
